### PR TITLE
feat: updgrade oarepo-ui to 7.0

### DIFF
--- a/template/pyproject.toml.copier
+++ b/template/pyproject.toml.copier
@@ -8,7 +8,7 @@ dependencies = [
     "json5",
     "oarepo[s3,rdm]>=14.0.0,<15.0.0",
     "oarepo-runtime>=2.0.0dev0,<3.0.0",
-    "oarepo-ui>=6.0.0dev0,<7.0.0",
+    "oarepo-ui>=7.0.0dev0,<8.0.0",
     "oarepo-model>=0.1.0dev0,<1.0.0",
     "oarepo-rdm>=1.0.0dev0,<2.0.0",
     "oarepo-theme>=1.0.0dev3,<2.0.0",


### PR DESCRIPTION
Requires these to be merged & released:

- https://github.com/oarepo/nrp-model-copier/pull/28
- https://github.com/oarepo/oarepo-ui/pull/409
- https://github.com/NRP-CZ/docs/pull/47
- [ ] notify users in mailing list: https://lists.cesnet.cz/wws/info/nrp-invenio telling them a migration step is needed when upgrading to oarepo-ui v7.0: https://nrp-cz.github.io/docs/administration/migrations#2026-02-18-oarepo-ui-v70-required-base-templates