### PR TITLE
Add .claude to .gitignore

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -387,3 +387,4 @@ pnpm-lock.yaml
 .invenio.private
 celerybeat-*
 .nrp
+.claude


### PR DESCRIPTION
## Summary
- Add `.claude` directory to `template/.gitignore` to exclude Claude Code configuration from generated projects

## Test plan
- [ ] Verify `.claude` directory is ignored in newly generated projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)