### PR TITLE
Track package-lock and pnpm-lock in source control

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -378,9 +378,6 @@ vite.config.ts.timestamp-*
 .DS_Store
 *.DS_Store?
 #
-package-lock.json
-pnpm-lock.yaml
-
 .invenio.private
 celerybeat-*
 .nrp


### PR DESCRIPTION
## What

Removes `package-lock.json` and `pnpm-lock.yaml` from the template `.gitignore`.

## Why

We want to use the **asset locking** feature, which pins JS/frontend dependencies to exact, reproducible versions. That feature relies on the lockfiles (`package-lock.json` / `pnpm-lock.yaml`) being present in source control.

While these files are ignored, each install can resolve dependencies differently, so the lock is effectively meaningless. Committing the lockfiles guarantees every checkout and CI run installs the exact same dependency tree, which is a prerequisite for the locking feature to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)