### PR TITLE
feat(template): add configure_files to invenio.cfg template

### DIFF
--- a/invenio.cfg.copier
+++ b/invenio.cfg.copier
@@ -33,6 +33,15 @@ config.register_workflow(
 
 config.configure_cron()
 
+# file upload quotas and file-related toggles
+config.configure_files(
+    max_file_size=1 * 10**9,
+    max_files_count=100,
+    max_total_size=5 * 10**9,
+    allow_metadata_only_records=True,
+    allow_empty_files=None,
+)
+
 # to enable datacite, uncomment the following lines
 # from common.config.datacite import (
 #               enable_datacite,


### PR DESCRIPTION
Adds `config.configure_files()` to the generated `invenio.cfg` template with commented defaults for quotas and file-related toggles.