### PR TITLE
feat(template): add configure_files to invenio.cfg template

### DIFF
--- a/template/invenio.cfg.copier
+++ b/template/invenio.cfg.copier
@@ -75,6 +75,15 @@ config.configure_stats()
 
 config.configure_cron()
 
+# file upload quotas and file-related toggles
+config.configure_files(
+    max_file_size=1 * 10**9,
+    max_files_count=100,
+    max_total_size=5 * 10**9,
+    allow_metadata_only_records=True,
+    allow_empty_files=None,
+)
+
 # to enable datacite, uncomment the following lines
 # from common.config.datacite import (
 #               enable_datacite,


### PR DESCRIPTION
Cherry-picks 6483dd0f918b13455eb6e1ea5afcb70584007a3a (feat(template): add configure_files to invenio.cfg template) onto `rdm-14`.

Adds `config.configure_files(...)` (file upload quotas and file-related toggles) to `template/invenio.cfg.copier` (the relocated path of `invenio.cfg.copier` on the `rdm-14` branch):

- `max_file_size=1 * 10**9`
- `max_files_count=100`
- `max_total_size=5 * 10**9`
- `allow_metadata_only_records=True`
- `allow_empty_files=None`